### PR TITLE
change group for operator and objects

### DIFF
--- a/deploy/crds/elmiko_v1alpha1_oshinkoapplication_crd.yaml
+++ b/deploy/crds/elmiko_v1alpha1_oshinkoapplication_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: oshinkoapplications.elmiko.dev
+  name: oshinkoapplications.radanalytics.io
 spec:
-  group: elmiko.dev
+  group: radanalytics.io
   names:
     kind: OshinkoApplication
     listKind: OshinkoApplicationList

--- a/deploy/crds/elmiko_v1alpha1_oshinkojob_crd.yaml
+++ b/deploy/crds/elmiko_v1alpha1_oshinkojob_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: oshinkojobs.elmiko.dev
+  name: oshinkojobs.radanalytics.io
 spec:
-  group: elmiko.dev
+  group: radanalytics.io
   names:
     kind: OshinkoJob
     listKind: OshinkoJobList

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -41,7 +41,7 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - elmiko.dev
+  - radanalytics.io
   resources:
   - '*'
   - oshinkojobs

--- a/examples/sparkpi-application.yaml
+++ b/examples/sparkpi-application.yaml
@@ -1,4 +1,4 @@
-apiVersion: elmiko.dev/v1alpha1
+apiVersion: radanalytics.io/v1alpha1
 kind: OshinkoApplication
 metadata:
   name: sparkpi

--- a/examples/sparkpi-job.yaml
+++ b/examples/sparkpi-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: elmiko.dev/v1alpha1
+apiVersion: radanalytics.io/v1alpha1
 kind: OshinkoJob
 metadata:
   name: sparkpi

--- a/molecule/test-cluster/playbook.yml
+++ b/molecule/test-cluster/playbook.yml
@@ -6,17 +6,17 @@
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
     deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
-    image_name: elmiko.dev/oshinko-oshizushi:testing
+    image_name: radanalytics.io/oshinko-oshizushi:testing
     custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/elmiko_v1alpha1_oshinkoapplication_cr.yaml'])) | from_yaml }}"
   tasks:
-  - name: Create the elmiko.dev/v1alpha1.OshinkoApplication
+  - name: Create the radanalytics.io/v1alpha1.OshinkoApplication
     k8s:
       namespace: '{{ namespace }}'
       definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/elmiko_v1alpha1_oshinkoapplication_cr.yaml'])) }}"
 
   - name: Get the newly created Custom Resource
     debug:
-      msg: "{{ lookup('k8s', group='elmiko.dev', api_version='v1alpha1', kind='OshinkoApplication', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
+      msg: "{{ lookup('k8s', group='radanalytics.io', api_version='v1alpha1', kind='OshinkoApplication', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
 
   - name: Wait 60s for reconciliation to run
     k8s_facts:

--- a/molecule/test-local/playbook.yml
+++ b/molecule/test-local/playbook.yml
@@ -3,7 +3,7 @@
 - name: Build Operator in Kubernetes docker container
   hosts: k8s
   vars:
-    image_name: elmiko.dev/oshinko-oshizushi:testing
+    image_name: radanalytics.io/oshinko-oshizushi:testing
   tasks:
   # using command so we don't need to install any dependencies
   - name: Get existing image hash
@@ -23,7 +23,7 @@
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
     deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
     pull_policy: Never
-    REPLACE_IMAGE: elmiko.dev/oshinko-oshizushi:testing
+    REPLACE_IMAGE: radanalytics.io/oshinko-oshizushi:testing
     custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/elmiko_v1alpha1_oshinkoapplication_cr.yaml'])) | from_yaml }}"
   tasks:
   - block:
@@ -54,7 +54,7 @@
         namespace: '{{ namespace }}'
         definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
 
-    - name: Create the elmiko.dev/v1alpha1.OshinkoApplication
+    - name: Create the radanalytics.io/v1alpha1.OshinkoApplication
       k8s:
         state: present
         namespace: '{{ namespace }}'

--- a/watches.yaml
+++ b/watches.yaml
@@ -1,9 +1,9 @@
 ---
 - version: v1alpha1
-  group: elmiko.dev
+  group: radanalytics.io
   kind: OshinkoApplication
   role: /opt/ansible/roles/oshinkoapplication
 - version: v1alpha1
-  group: elmiko.dev
+  group: radanalytics.io
   kind: OshinkoJob
   role: /opt/ansible/roles/oshinkojob


### PR DESCRIPTION
As part of the migration to the radanalytics repo, the grouping is being
changed from `elmiko.dev` to `radanalytics.io`.