### PR TITLE
change build-image in example job

### DIFF
--- a/examples/sparkpi-job.yaml
+++ b/examples/sparkpi-job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sparkpi
 spec:
   build-type: "python27"
-  build-image: "quay.io/elmiko/radanalytics-pyspark:override-cluster-check"
+  build-image: "quay.io/radanalyticsio/oshinko-s2i-pyspark:latest"
   git-uri: "https://github.com/elmiko/sparkpi-job.git"
   spark-options:
     - "--conf spark.driver.bindAddress=0.0.0.0"


### PR DESCRIPTION
this is being done to migrate away from the personal registry image to
an image maintained by the radanalytics team.