### PR TITLE
Update job cluster

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Oshizushi examples
+
+The manifests contained in this directory demonstrate various features of the
+oshinko-oshizushi operator.
+
+* `sparkpi-application.yaml` - Deploys an HTTP service which will compute the
+  value of Pi when requested. It will automatically spawn a Spark cluster for
+  the service. For more information about how this service functions, see
+  [this radanalytics.io tutorial](https://radanalytics.io/my-first-radanalytics-app.html).
+
+* `sparkpi-job.yaml` - Deploys a Spark cluster and runs a kubernetes job to
+  calculate the value of Pi. It will destroy the Spark cluster after a
+  successful job completion. Examine the logs of the job pod to see the results.
+
+* `sparkpi-job-override.yaml` - Runs the Pi calculation job using a pre-existing
+  cluster. You must provide the Spark cluster to make this example function.

--- a/examples/sparkpi-job-override.yaml
+++ b/examples/sparkpi-job-override.yaml
@@ -1,0 +1,13 @@
+apiVersion: radanalytics.io/v1alpha1
+kind: OshinkoJob
+metadata:
+  name: sparkpi
+spec:
+  build-type: "python27"
+  build-image: "quay.io/radanalyticsio/oshinko-s2i-pyspark:latest"
+  git-uri: "https://github.com/elmiko/sparkpi-job.git"
+  spark-url-override: "spark://my-spark-cluster:7077"
+  spark-options:
+    - "--conf spark.driver.bindAddress=0.0.0.0"
+    - "--conf spark.driver.blockManager.port=7079"
+    - "--conf spark.driver.port=7078"

--- a/roles/oshinkojob/tasks/main.yml
+++ b/roles/oshinkojob/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: determine job completion
   vars:
-    job: "{{ lookup('k8s', kind='Job',
+    job: "{{ lookup('k8s', kind='Job', api_version='batch/v1',
                      namespace=meta.namespace, resource_name=meta.name) }}"
   when: (job.status.succeeded | default(0) == completions) and (state == "present")
   set_fact:
     job_completed: true
 
 - name: create spark cluster
-  when: (state == "present") and (job_completed | default(false) == false)
+  when: (state == "present") and (job_completed | default(false) == false) and (spark_url_override == None)
   k8s:
     state: "{{ state }}"
     definition:
@@ -43,6 +43,7 @@
   when: state == "present"
   vars:
     imagestream: "{{ lookup('k8s', kind='ImageStream',
+                     api_version='image.openshift.io/v1',
                      namespace=meta.namespace, resource_name=meta.name) }}"
   set_fact:
     imagestream_repository: "{{ imagestream.status.dockerImageRepository }}"
@@ -92,7 +93,7 @@
 
 - name: determine build completion
   vars:
-    build: "{{ lookup('k8s', kind='Build',
+    build: "{{ lookup('k8s', kind='Build', api_version='build.openshift.io/v1',
                      namespace=meta.namespace, resource_name=meta.name+'-1') }}"
   when: (build.status.phase == "Complete") and (state == "present")
   set_fact:
@@ -146,7 +147,7 @@
               - name: OSHINKO_SPARK_DRIVER_CONFIG
                 value: "{{ driver_config }}"
               - name: SPARK_URL_OVERRIDE
-                value: "spark://{{ meta.name }}-spark:7077"
+                value: "{{ spark_url_override| default('spark://'+meta.name+'-spark:7077') }}"
               - name: POD_NAME
                 valueFrom:
                   fieldRef:
@@ -191,7 +192,7 @@
           app: "{{ meta.name }}"
 
 - name: delete spark cluster
-  when: job_completed | default(false) == true
+  when: (job_completed | default(false) == true) and (spark_url_override == None)
   k8s:
     state: "absent"
     definition:

--- a/roles/oshinkojob/tasks/main.yml
+++ b/roles/oshinkojob/tasks/main.yml
@@ -147,7 +147,7 @@
               - name: OSHINKO_SPARK_DRIVER_CONFIG
                 value: "{{ driver_config }}"
               - name: SPARK_URL_OVERRIDE
-                value: "{{ spark_url_override| default('spark://'+meta.name+'-spark:7077') }}"
+                value: "{% if spark_url_override == None %}spark://{{ meta.name }}-spark:7077{% else %}{{ spark_url_override }}{% endif %}"
               - name: POD_NAME
                 valueFrom:
                   fieldRef:


### PR DESCRIPTION
Adds the ability to override the Spark cluster for OshinkoJob resources. Also cleans up some of the lookup code for OpenShift 4+.