### PR TITLE
add templates for oshinkojobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 An operator that encapsulates the source-to-image process for creating Apache
 Spark based Deployments and Jobs within OpenShift.
 
+## Dependencies
+
+This operator requires that you also have the
+[Apache Spark Operator](https://operatorhub.io/operator/radanalytics-spark) installed.
+
 ## Quickstart
 
 **Prerequisites**

--- a/examples/oshinkojob-sparkpi-java.yaml
+++ b/examples/oshinkojob-sparkpi-java.yaml
@@ -1,0 +1,12 @@
+apiVersion: radanalytics.io/v1alpha1
+kind: OshinkoJob
+metadata:
+  name: sparkpi
+spec:
+  build-type: "java"
+  git-uri: "https://github.com/radanalyticsio/s2i-integration-test-apps.git"
+  app-file: "java-spark-pi-1.0-SNAPSHOT-jar-with-dependencies.jar"
+  spark-options:
+    - "--conf spark.driver.bindAddress=0.0.0.0"
+    - "--conf spark.driver.blockManager.port=7079"
+    - "--conf spark.driver.port=7078"

--- a/examples/oshinkojob-sparkpi-python27.yaml
+++ b/examples/oshinkojob-sparkpi-python27.yaml
@@ -4,8 +4,7 @@ metadata:
   name: sparkpi
 spec:
   build-type: "python27"
-  build-image: "quay.io/radanalyticsio/oshinko-s2i-pyspark:latest"
-  git-uri: "https://github.com/elmiko/sparkpi-job.git"
+  git-uri: "https://github.com/radanalyticsio/s2i-integration-test-apps.git"
   spark-options:
     - "--conf spark.driver.bindAddress=0.0.0.0"
     - "--conf spark.driver.blockManager.port=7079"

--- a/examples/oshinkojob-sparkpi-scala.yaml
+++ b/examples/oshinkojob-sparkpi-scala.yaml
@@ -1,0 +1,12 @@
+apiVersion: radanalytics.io/v1alpha1
+kind: OshinkoJob
+metadata:
+  name: sparkpi
+spec:
+  build-type: "scala"
+  git-uri: "https://github.com/radanalyticsio/s2i-integration-test-apps.git"
+  app-file: "sparkpi_2.11-0.1.jar"
+  spark-options:
+    - "--conf spark.driver.bindAddress=0.0.0.0"
+    - "--conf spark.driver.blockManager.port=7079"
+    - "--conf spark.driver.port=7078"

--- a/roles/oshinkojob/tasks/main.yml
+++ b/roles/oshinkojob/tasks/main.yml
@@ -48,48 +48,10 @@
   set_fact:
     imagestream_repository: "{{ imagestream.status.dockerImageRepository }}"
 
-- name: create python27 buildconfig
-  when: (build_type|lower == 'python') or (build_type|lower == 'python27')
+- name: create buildconfig
   k8s:
     state: "{{ state }}"
-    definition:
-      apiVersion: build.openshift.io/v1
-      kind: BuildConfig
-      metadata:
-        name: "{{ meta.name }}"
-        namespace: "{{ meta.namespace }}"
-        labels:
-          app: "{{ meta.name }}"
-      spec:
-        output:
-          to:
-            kind: ImageStreamTag
-            name: "{{ meta.name }}:latest"
-        source:
-          contextDir: "{{ context_dir }}"
-          git:
-            ref: "{{ git_ref }}"
-            uri: "{{ git_uri }}"
-          type: Git
-        strategy:
-          sourceStrategy:
-            env:
-              - name: APP_FILE
-                value: "{{ app_file | default('app.py') }}"
-            from:
-              kind: DockerImage
-              name: "{{ build_image }}"
-          type: Source
-        triggers:
-        - imageChange: {}
-          type: ImageChange
-        - type: ConfigChange
-        - github:
-            secret: "{{ meta.name }}"
-          type: GitHub
-        - generic:
-            secret: "{{ meta.name }}"
-          type: Generic
+    definition: "{{ lookup('template', 'buildconfig.yaml.j2') }}"
 
 - name: determine build completion
   vars:
@@ -103,69 +65,7 @@
   when: (state == "present") and (build_completed | default(false) == true)
   k8s:
     state: "{{ state }}"
-    definition:
-      apiVersion: batch/v1
-      kind: Job
-      metadata:
-        name: "{{ meta.name }}"
-        namespace: "{{ meta.namespace }}"
-        labels:
-          app: "{{ meta.name }}"
-      spec:
-        completions: "{{ completions }}"
-        parallelism: 1
-        selector:
-          radanalytics.io/Job: "{{ meta.name }}"
-        template:
-          metadata:
-            labels:
-              radanalytics.io/Job: "{{ meta.name }}"
-              app: "{{ meta.name }}"
-            name: "{{ meta.name }}"
-          spec:
-            containers:
-            - name: "{{ meta.name }}"
-              env:
-              - name: APPLICATION_NAME
-                value: "{{ meta.name }}"
-              - name: DRIVER_HOST
-                value: "{{ meta.name }}-headless"
-              - name: OSHINKO_CLUSTER_NAME
-                value: "{{ oshinko_cluster_name }}"
-              - name: APP_ARGS
-                value: "{{ app_args }}"
-              - name: SPARK_OPTIONS
-                value: "{{ spark_options|join(' ') }}"
-              - name: APP_MAIN_CLASS
-                value: "{{ app_main_class }}"
-              - name: OSHINKO_DEL_CLUSTER
-                value: "{{ delete_cluster }}"
-              - name: APP_EXIT
-                value: "{{ app_exit }}"
-              - name: OSHINKO_NAMED_CONFIG
-                value: "{{ cluster_config }}"
-              - name: OSHINKO_SPARK_DRIVER_CONFIG
-                value: "{{ driver_config }}"
-              - name: SPARK_URL_OVERRIDE
-                value: "{% if spark_url_override == None %}spark://{{ meta.name }}-spark:7077{% else %}{{ spark_url_override }}{% endif %}"
-              - name: POD_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.name
-              image: "{{ imagestream_repository }}:latest"
-              volumeMounts:
-              - mountPath: /etc/podinfo
-                name: podinfo
-                readOnly: false
-            restartPolicy: Never
-            serviceAccountName: oshinko-oshizushi
-            volumes:
-            - downwardAPI:
-              items:
-              - fieldRef:
-                fieldPath: metadata.labels
-                path: labels
-              name: podinfo
+    definition: "{{ lookup('template', 'job.yaml.j2') }}"
 
 - name: create headless service
   k8s:

--- a/roles/oshinkojob/templates/buildconfig.yaml.j2
+++ b/roles/oshinkojob/templates/buildconfig.yaml.j2
@@ -1,0 +1,56 @@
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: "{{ meta.name }}"
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: "{{ meta.name }}"
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: "{{ meta.name }}:latest"
+  source:
+    contextDir: "{{ context_dir }}"
+    git:
+      ref: "{{ git_ref }}"
+      uri: "{{ git_uri }}"
+    type: Git
+  strategy:
+    sourceStrategy:
+      env:
+        - name: APP_FILE
+{% if (build_type|lower == 'python') or (build_type|lower == 'python27') %}
+          value: "{{ app_file | default('app.py') }}"
+{% else %}
+          value: "{{ app_file }}"
+{% endif %}
+{% if build_type|lower == 'scala' %}
+        - name: SBT_ARGS
+          value: "{{ sbt_args }}"
+        - name: SBT_ARGS_APPEND
+          value: "{{ sbt_args_append }}"
+{% endif %}
+      from:
+        kind: DockerImage
+{% if (build_type|lower == 'python') or (build_type|lower == 'python27') %}
+        name: "quay.io/radanalyticsio/oshinko-s2i-pyspark:latest"
+{% elif (build_type|lower == 'java') %}
+        name: "quay.io/radanalyticsio/oshinko-s2i-java-spark:latest"
+{% elif (build_type|lower == 'scala') %}
+        name: "quay.io/radanalyticsio/oshinko-s2i-scala-spark:latest"
+{% else %}
+        name: "{{ build_image }}"
+{% endif %}
+    type: Source
+  triggers:
+  - imageChange: {}
+    type: ImageChange
+  - type: ConfigChange
+  - github:
+      secret: "{{ meta.name }}"
+    type: GitHub
+  - generic:
+      secret: "{{ meta.name }}"
+    type: Generic

--- a/roles/oshinkojob/templates/job.yaml.j2
+++ b/roles/oshinkojob/templates/job.yaml.j2
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ meta.name }}"
+  namespace: "{{ meta.namespace }}"
+  labels:
+    app: "{{ meta.name }}"
+spec:
+  completions: {{ completions }}
+  parallelism: 1
+  selector:
+    radanalytics.io/Job: "{{ meta.name }}"
+  template:
+    metadata:
+      labels:
+        radanalytics.io/Job: "{{ meta.name }}"
+        app: "{{ meta.name }}"
+      name: "{{ meta.name }}"
+    spec:
+      containers:
+      - name: "{{ meta.name }}"
+        env:
+        - name: APPLICATION_NAME
+          value: "{{ meta.name }}"
+        - name: DRIVER_HOST
+          value: "{{ meta.name }}-headless"
+        - name: OSHINKO_CLUSTER_NAME
+          value: "{{ oshinko_cluster_name }}"
+        - name: APP_ARGS
+          value: "{{ app_args }}"
+        - name: SPARK_OPTIONS
+          value: "{{ spark_options|join(' ') }}"
+{% if (build_type|lower == 'java') or (build_type|lower == 'scala') %}
+        - name: APP_MAIN_CLASS
+          value: "{{ app_main_class }}"
+{% endif %}
+        - name: OSHINKO_DEL_CLUSTER
+          value: "{{ delete_cluster }}"
+        - name: APP_EXIT
+          value: "{{ app_exit }}"
+        - name: OSHINKO_NAMED_CONFIG
+          value: "{{ cluster_config }}"
+        - name: OSHINKO_SPARK_DRIVER_CONFIG
+          value: "{{ driver_config }}"
+        - name: SPARK_URL_OVERRIDE
+          value: "{% if spark_url_override == None %}spark://{{ meta.name }}-spark:7077{% else %}{{ spark_url_override }}{% endif %}"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: "{{ imagestream_repository }}:latest"
+        volumeMounts:
+        - mountPath: /etc/podinfo
+          name: podinfo
+          readOnly: false
+      restartPolicy: Never
+      serviceAccountName: oshinko-oshizushi
+      volumes:
+      - downwardAPI:
+        items:
+        - fieldRef:
+          fieldPath: metadata.labels
+          path: labels
+        name: podinfo
+

--- a/roles/oshinkojob/vars/main.yml
+++ b/roles/oshinkojob/vars/main.yml
@@ -14,5 +14,7 @@ app_exit: "true"
 cluster_config: null
 driver_config: null
 spark_url_override: null
-build_image: "docker.io/radanalyticsio/radanalytics-pyspark:stable"
+build_image: null
 delete_job: false
+sbt_args: null
+sbt_args_append: null


### PR DESCRIPTION
this also adds builds for java and scala build, and example manifests.
the readme has been updated to reflect the dependency on spark operator.