### PR TITLE
convert applications to use spark operator

### DIFF
--- a/roles/oshinkoapplication/tasks/main.yml
+++ b/roles/oshinkoapplication/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+- name: create spark cluster
+  when: spark_url_override == None
+  k8s:
+    state: "{{ state }}"
+    definition:
+      apiVersion: radanalytics.io/v1
+      kind: SparkCluster
+      metadata:
+        name: "{{ meta.name }}-spark"
+        namespace: "{{ meta.namespace }}"
+      spec:
+        worker:
+          instances: "{{ executors }}"
+        master:
+          instances: "1"
+
 - name: create imagestream
   k8s:
     state: "{{ state }}"

--- a/roles/oshinkoapplication/templates/buildconfig.yaml.j2
+++ b/roles/oshinkoapplication/templates/buildconfig.yaml.j2
@@ -35,11 +35,11 @@ spec:
       from:
         kind: DockerImage
 {% if (build_type|lower == 'python') or (build_type|lower == 'python27') %}
-        name: "docker.io/radanalyticsio/radanalytics-pyspark:stable"
+        name: "quay.io/radanalyticsio/oshinko-s2i-pyspark:latest"
 {% elif (build_type|lower == 'java') %}
-        name: "docker.io/radanalyticsio/radanalytics-java-spark:stable"
+        name: "quay.io/radanalyticsio/oshinko-s2i-java-spark:latest"
 {% elif (build_type|lower == 'scala') %}
-        name: "docker.io/radanalyticsio/radanalytics-scala-spark:stable"
+        name: "quay.io/radanalyticsio/oshinko-s2i-scala-spark:latest"
 {% else %}
         name: "{{ build_image }}"
 {% endif %}

--- a/roles/oshinkoapplication/templates/deploymentconfig.yaml.j2
+++ b/roles/oshinkoapplication/templates/deploymentconfig.yaml.j2
@@ -41,7 +41,7 @@ spec:
         - name: OSHINKO_SPARK_DRIVER_CONFIG
           value: "{{ driver_config }}"
         - name: SPARK_URL_OVERRIDE
-          value: "{{ spark_url_override }}"
+          value: "{% if spark_url_override == None %}spark://{{ meta.name }}-spark:7077{% else %}{{ spark_url_override }}{% endif %}"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/roles/oshinkoapplication/vars/main.yml
+++ b/roles/oshinkoapplication/vars/main.yml
@@ -17,3 +17,4 @@ app_main_class: null
 app_file: null
 sbt_args: null
 sbt_args_append: null
+executors: 1


### PR DESCRIPTION
this change makes the oshinkoapplication resource now use spark-operator
generated clusters. it also means that oshizushi is now fully dependent
on spark-operator.