### PR TITLE
move spark defaults inside the operator

### DIFF
--- a/examples/oshinkoapplication-sparkpi-java.yaml
+++ b/examples/oshinkoapplication-sparkpi-java.yaml
@@ -6,8 +6,3 @@ spec:
   build-type: "java"
   git-uri: "https://github.com/radanalyticsio/tutorial-sparkpi-java-spring.git"
   app_file: "SparkPiBoot-0.0.1-SNAPSHOT.jar"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"
-

--- a/examples/oshinkoapplication-sparkpi-python27.yaml
+++ b/examples/oshinkoapplication-sparkpi-python27.yaml
@@ -5,8 +5,3 @@ metadata:
 spec:
   build-type: "python27"
   git-uri: "https://github.com/radanalyticsio/tutorial-sparkpi-python-flask.git"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"
-

--- a/examples/oshinkoapplication-sparkpi-python36.yaml
+++ b/examples/oshinkoapplication-sparkpi-python36.yaml
@@ -5,8 +5,3 @@ metadata:
 spec:
   build-type: "python36"
   git-uri: "https://github.com/radanalyticsio/tutorial-sparkpi-python-flask.git"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"
-

--- a/examples/oshinkoapplication-sparkpi-scala.yaml
+++ b/examples/oshinkoapplication-sparkpi-scala.yaml
@@ -9,8 +9,3 @@ spec:
   app_file: "tutorial-sparkpi-scala-scalatra-assembly-0.0.1-SNAPSHOT.jar"
   sbt_args: "clean assembly"
   app_args: "-Xms1024M, -Xmx2048M, -XX:MaxMetaspace=1024M"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"
-

--- a/examples/oshinkojob-sparkpi-java.yaml
+++ b/examples/oshinkojob-sparkpi-java.yaml
@@ -6,7 +6,3 @@ spec:
   build-type: "java"
   git-uri: "https://github.com/radanalyticsio/s2i-integration-test-apps.git"
   app-file: "java-spark-pi-1.0-SNAPSHOT-jar-with-dependencies.jar"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"

--- a/examples/oshinkojob-sparkpi-python27.yaml
+++ b/examples/oshinkojob-sparkpi-python27.yaml
@@ -5,7 +5,3 @@ metadata:
 spec:
   build-type: "python27"
   git-uri: "https://github.com/radanalyticsio/s2i-integration-test-apps.git"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"

--- a/examples/oshinkojob-sparkpi-python36.yaml
+++ b/examples/oshinkojob-sparkpi-python36.yaml
@@ -5,7 +5,3 @@ metadata:
 spec:
   build-type: "python36"
   git-uri: "https://github.com/radanalyticsio/s2i-integration-test-apps.git"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"

--- a/examples/oshinkojob-sparkpi-scala.yaml
+++ b/examples/oshinkojob-sparkpi-scala.yaml
@@ -6,7 +6,3 @@ spec:
   build-type: "scala"
   git-uri: "https://github.com/radanalyticsio/s2i-integration-test-apps.git"
   app-file: "sparkpi_2.11-0.1.jar"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"

--- a/examples/sparkpi-job-override.yaml
+++ b/examples/sparkpi-job-override.yaml
@@ -7,7 +7,3 @@ spec:
   build-image: "quay.io/radanalyticsio/oshinko-s2i-pyspark:latest"
   git-uri: "https://github.com/elmiko/sparkpi-job.git"
   spark-url-override: "spark://my-spark-cluster:7077"
-  spark-options:
-    - "--conf spark.driver.bindAddress=0.0.0.0"
-    - "--conf spark.driver.blockManager.port=7079"
-    - "--conf spark.driver.port=7078"

--- a/roles/oshinkoapplication/templates/deploymentconfig.yaml.j2
+++ b/roles/oshinkoapplication/templates/deploymentconfig.yaml.j2
@@ -27,7 +27,11 @@ spec:
         - name: APP_ARGS
           value: "{{ app_args }}"
         - name: SPARK_OPTIONS
-          value: "{{ spark_options|join(' ') }}"
+{% if spark_options == None %}
+          value: "{{ spark_default_options }}"
+{% else %}
+          value: "{{ spark_default_options }} {{ spark_options|join(' ') }}"
+{% endif %}
 {% if (build_type|lower == 'java') or (build_type|lower == 'scala') %}
         - name: APP_MAIN_CLASS
           value: "{{ app_main_class }}"

--- a/roles/oshinkoapplication/vars/main.yml
+++ b/roles/oshinkoapplication/vars/main.yml
@@ -19,3 +19,4 @@ sbt_args: null
 sbt_args_append: null
 executors: 1
 spark_image: null
+spark_default_options: "--conf spark.driver.bindAddress=0.0.0.0 --conf spark.driver.blockManager.port=7079 --conf spark.driver.port=7078"

--- a/roles/oshinkojob/templates/job.yaml.j2
+++ b/roles/oshinkojob/templates/job.yaml.j2
@@ -30,7 +30,11 @@ spec:
         - name: APP_ARGS
           value: "{{ app_args }}"
         - name: SPARK_OPTIONS
-          value: "{{ spark_options|join(' ') }}"
+{% if spark_options == None %}
+          value: "{{ spark_default_options }}"
+{% else %}
+          value: "{{ spark_default_options }} {{ spark_options|join(' ') }}"
+{% endif %}
 {% if (build_type|lower == 'java') or (build_type|lower == 'scala') %}
         - name: APP_MAIN_CLASS
           value: "{{ app_main_class }}"

--- a/roles/oshinkojob/vars/main.yml
+++ b/roles/oshinkojob/vars/main.yml
@@ -19,3 +19,4 @@ delete_job: false
 sbt_args: null
 sbt_args_append: null
 spark_image: null
+spark_default_options: "--conf spark.driver.bindAddress=0.0.0.0 --conf spark.driver.blockManager.port=7079 --conf spark.driver.port=7078"


### PR DESCRIPTION
there are a couple connection variables that are needed to help the
spark containers find and connect to each other. this change makes those
configurations internal to the operator so that a user does not need to
know them.