### PR TITLE
Add spark-operator configmap support

### DIFF
--- a/roles/oshinkoapplication/templates/sparkcluster.yaml.j2
+++ b/roles/oshinkoapplication/templates/sparkcluster.yaml.j2
@@ -1,4 +1,24 @@
 ---
+{% if spark_operator_use_configmap %}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ meta.name }}-spark"
+  namespace: "{{ meta.namespace }}"
+  labels:
+    radanalytics.io/kind: SparkCluster
+data:
+  config: |-
+{% if spark_image %}
+    customImage: "{{ spark_image }}"
+{% elif build_type|lower == 'python36' %}
+    customImage: "quay.io/radanalyticsio/openshift-spark-py36:2.4-latest"
+{% endif %}
+    worker:
+      instances: "{{ executors }}"
+    master:
+      instances: "1"
+{% else %}
 apiVersion: radanalytics.io/v1
 kind: SparkCluster
 metadata:
@@ -14,3 +34,4 @@ spec:
     instances: "{{ executors }}"
   master:
     instances: "1"
+{% endif %}

--- a/roles/oshinkoapplication/vars/main.yml
+++ b/roles/oshinkoapplication/vars/main.yml
@@ -21,3 +21,4 @@ executors: 1
 spark_image: null
 spark_default_options: "--conf spark.driver.bindAddress=0.0.0.0 --conf spark.driver.blockManager.port=7079 --conf spark.driver.port=7078"
 environment_variables: []
+spark_operator_use_configmap: false

--- a/roles/oshinkojob/tasks/main.yml
+++ b/roles/oshinkojob/tasks/main.yml
@@ -85,10 +85,4 @@
   when: (job_completed | default(false) == true) and (spark_url_override == None)
   k8s:
     state: "absent"
-    definition:
-      apiVersion: radanalytics.io/v1
-      kind: SparkCluster
-      metadata:
-        name: "{{ meta.name }}-spark"
-        namespace: "{{ meta.namespace }}"
-      spec: {}
+    definition: "{{ lookup('template', 'sparkcluster.yaml.j2') }}"

--- a/roles/oshinkojob/templates/sparkcluster.yaml.j2
+++ b/roles/oshinkojob/templates/sparkcluster.yaml.j2
@@ -1,4 +1,24 @@
 ---
+{% if spark_operator_use_configmap %}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ meta.name }}-spark"
+  namespace: "{{ meta.namespace }}"
+  labels:
+    radanalytics.io/kind: SparkCluster
+data:
+  config: |-
+{% if spark_image %}
+    customImage: "{{ spark_image }}"
+{% elif build_type|lower == 'python36' %}
+    customImage: "quay.io/radanalyticsio/openshift-spark-py36:2.4-latest"
+{% endif %}
+    worker:
+      instances: "{{ executors }}"
+    master:
+      instances: "1"
+{% else %}
 apiVersion: radanalytics.io/v1
 kind: SparkCluster
 metadata:
@@ -14,3 +34,4 @@ spec:
     instances: "{{ executors }}"
   master:
     instances: "1"
+{% endif %}

--- a/roles/oshinkojob/vars/main.yml
+++ b/roles/oshinkojob/vars/main.yml
@@ -21,3 +21,4 @@ sbt_args_append: null
 spark_image: null
 spark_default_options: "--conf spark.driver.bindAddress=0.0.0.0 --conf spark.driver.blockManager.port=7079 --conf spark.driver.port=7078"
 environment_variables: []
+spark_operator_use_configmap: false


### PR DESCRIPTION
the spark-operator can use config maps instead of crds for its cluster, this change brings in a binary cr schema variable named `spark-operator-use-configmap` which can be used to enable this support.